### PR TITLE
demonstration of building wheel with SCons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,62 @@
+# Starter SConstruct for enscons
+
+import sys
+from distutils import sysconfig
+import pytoml as toml
+import enscons
+import build
+
+metadata = dict(toml.load(open('pyproject.toml')))['tool']['enscons']
+
+# most specific binary, non-manylinux1 tag should be at the top of this list
+import wheel.pep425tags
+plat_tag = next(tag for tag in wheel.pep425tags.get_supported())[-1]
+full_tag = '-'.join(('py2.py3', 'none', plat_tag))
+
+env = Environment(tools=['default', 'packaging', enscons.generate],
+                  PACKAGE_METADATA=metadata,
+                  WHEEL_TAG=full_tag,
+                  ROOT_IS_PURELIB=full_tag.endswith('-any'))
+
+lib_path = 'libsourcemap/_libsourcemap.so'
+rust_libname = 'liblibsourcemap' + env['SHLIBSUFFIX']
+rust_lib = 'target/release/' + rust_libname
+
+# Build rust
+env.Command(
+        target=rust_lib,
+        source=["Cargo.toml"] + Glob("src/*.rs"),
+        action="cargo build --release"
+        )
+
+# Copy compiled library into base directory
+local_rust = env.Command(
+        target=lib_path,
+        source=rust_lib,
+        action=Copy('$TARGET', '$SOURCE'))
+
+# build cffi Python
+def build_py(target, source, env):
+    build.ffi.emit_python_code(str(target[0]))
+
+cffi_py = env.Command(
+    target='libsourcemap/_sourcemapnative.py',
+    source=['build.py', 'include/libsourcemap.h'],
+    action=build_py
+)
+
+# Add extra files or package_data here.
+# cffi_py catches _sourcemapnative.py before it has been built.
+# targets must be added to the wheel exactly once.
+py_source = list(set(Glob('libsourcemap/*.py') + cffi_py))
+
+platlib = env.Whl('platlib', py_source + [lib_path], root='')
+whl = env.WhlFile(platlib)
+
+# Add automatic source files, plus any other needed files.
+sdist_source=FindSourceFiles() + ['PKG-INFO', 'setup.py']
+
+sdist = env.SDist(source=sdist_source)
+
+env.NoClean(sdist)
+env.Alias('sdist', sdist)

--- a/SConstruct
+++ b/SConstruct
@@ -22,6 +22,9 @@ lib_path = 'libsourcemap/_libsourcemap.so'
 rust_libname = 'liblibsourcemap' + env['SHLIBSUFFIX']
 rust_lib = 'target/release/' + rust_libname
 
+# Cargo doesn't seem to rebuild this if missing
+env.NoClean(rust_lib)
+
 # Build rust
 env.Command(
         target=rust_lib,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.enscons]
+name = "libsourcemap"
+version = "0.5.0"
+description = "Helps working with sourcemaps."
+classifiers = ["Intended Audience :: Developers", "License :: OSI Approved :: BSD License", "Operating System :: OS Independent", "Programming Language :: Python", "Topic :: Internet :: WWW/HTTP :: Dynamic Content", "Topic :: Software Development :: Libraries :: Python Modules"]
+author = "Sentry"
+author_email = "hello@getsentry.com"
+url = "http://github.com/getsentry/libsourcemap"
+license = "BSD"
+install_requires = ["cffi>=1.6.0"]
+packages = ["libsourcemap"]
+src_root = ""
+
+[build-system]
+requires = ["pytoml>=0.1", "enscons"]


### PR DESCRIPTION
Here's an example SConstruct to build a wheel for your project. It provides build rules with dependency tracking and gives complete control of the wheel tag. Unlike the setup.py build it avoids putting an extraneous purelib/ directory in the wheel.

To build, `pip install enscons` and `python -m SCons`. Tested in Python 2.7. enscons is a small project that adds wheel generation to SCons.